### PR TITLE
Clear output to webserver from predict.py

### DIFF
--- a/ml/predict.py
+++ b/ml/predict.py
@@ -151,6 +151,9 @@ def ordinal(n: int) -> str:
 
 
 def main(design_problem: str = ""):
+    # Reset output
+    output.clear()
+
     # Handle command line execution
     if not design_problem:
         design_problem = sys.argv[1]


### PR DESCRIPTION
Ben had an issue with the output from predict.py to the web server where the output from each algorithm was being duplicated for an increasing number of times. He determined that the issue was that the output to the web app was not being cleared for every run, so he recommended adding a statement to clear the output at the beginning of predict.py's main function.